### PR TITLE
Time slicer func

### DIFF
--- a/eg.py
+++ b/eg.py
@@ -24,7 +24,7 @@ get_ipython().magic('reset -sf')
 importing zone
 ------------------------------------------------------------------------------
 """
-from sim_db import sim
+from sim_db import sim, search_time, sph_time
 from eigpp  import epp
 import plotter
 """
@@ -38,11 +38,11 @@ case1=sim() # this will contain data corresponding to a particular simulation (a
 case1.fName='eg' # output binary file name (without extension)
 case1.stru.name='str ex raw data'
 case1.stru.nodes=[200000, 200010] # nodes of interest - only information relative to these nodes is going to be read
-case1.stru.struRdOpt = 'raw' # set flag for reading ASCII file - default 'bin'
+case1.stru.struRdOpt = 'bin' # set flag for reading ASCII file - default 'bin'
 case1.stru.p11FN='pcolgante.@1' # binary *.p11 file name (without extension - Simpact output) from wich extract generalized displacements
 case1.stru.rsnDe='pcolgante' # ASCII *.rsn file name (without extension) - Delta output
 case1.stru.loadsFN = 'AeroFcsOnStruc' #ASCII *.dat file name - Loads
-case1.stru.loadRdOpt = 'raw'
+case1.stru.loadRdOpt = 'bin'
 
 # eigen modes postprocess
 #   call the function
@@ -63,11 +63,19 @@ desired = {'200000':[1]}
 
 #Tests
 import numpy as np
-# case1.stru.t = np.linspace(0,100,5000)
-# case1.stru.u_avr = np.zeros((2,5000))
-# case1.stru.q = np.copy(case1.stru.u_avr)
-# case1.stru.u_avr[1] = np.sin(8*case1.stru.t)
-# case1.stru.q = np.copy(case1.stru.u_avr)
+case1.stru.t = np.linspace(0,200,5000)
+case1.stru.u_avr = np.zeros((2,5000))
+case1.stru.q = np.copy(case1.stru.u_avr)
+case1.stru.u_avr[1] = np.sin(8*case1.stru.t)
+case1.stru.q = np.copy(case1.stru.u_avr)
+
+# Test recortar
+#por valor
+case1.stru = sph_time(case1.stru, **{'time_vals':[100,180]})
+#por indice
+case1.stru = sph_time(case1.stru, **{'indexes':[0,5]})
+
+#Tests ploteos
 
 # # plotter.fig_ut_vt_pp(case1.stru,desired,fig_title='gg')
 # # plotter.fig_u_spect(case1.stru, desired, fig_title = 'FFT')


### PR DESCRIPTION
Se agregó función sph_time en sim_db para "slicear" t, q, u_i y poder plotear lo que interese. Genero pull req para discutir la idea. Si anda, ya la incorporo a la branch que uso para trabajar.

La función `sph_time` recibe un obj stru y una lista que puede contener dos tiempos o dos índices de tiempo `[start, end]` y procede:

- Si son índices, simplemente slicea `t, u_avr, u_raw, q` para los mismos: `array[indx_0:indx_1]`
- Si son tiempos, llama a `search_time`; función que busca para ambos elementos el inmediato superior (si existe) y devuelve los índices correspondientes.

Se me ocurrió buscar más "rápido" buscando a "ojo" el índice posible, determinando el `dt=t[1]-t[0]` e iniciando un poco después un loop (en lugar de recorrer desde 0 el array t):
`for i in (guess, len(t_array)`

Esto no sé si va a funcionar cuando los `dt` no sean uniformes. Se podría tomar un `dt` promedio y saltar unos cuantos indices antes por las dudas...